### PR TITLE
Map research

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,8 +4,8 @@
  :aliases
  {;; Run with clj -T:build function-in-build
   :dev
-  {:extra-deps {;;org.clojure/clojure {:mvn/version "1.12.0-CN-SNAPSHOT"}
-                org.clojure/clojure {:mvn/version "1.11.1"}
+  {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0-CN-SNAPSHOT"}
+                ;;org.clojure/clojure {:mvn/version "1.11.1"}
                 criterium/criterium {:mvn/version "0.4.5"}
                 techascent/tech.ml.dataset {:mvn/version "7.000-beta-34"}
                 ch.qos.logback/logback-classic {:mvn/version "1.1.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,8 @@
  :aliases
  {;; Run with clj -T:build function-in-build
   :dev
-  {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}
+  {:extra-deps {;;org.clojure/clojure {:mvn/version "1.12.0-CN-SNAPSHOT"}
+                org.clojure/clojure {:mvn/version "1.11.1"}
                 criterium/criterium {:mvn/version "0.4.5"}
                 techascent/tech.ml.dataset {:mvn/version "7.000-beta-34"}
                 ch.qos.logback/logback-classic {:mvn/version "1.1.3"}

--- a/deps.edn
+++ b/deps.edn
@@ -4,8 +4,8 @@
  :aliases
  {;; Run with clj -T:build function-in-build
   :dev
-  {:extra-deps {org.clojure/clojure {:mvn/version "1.12.0-CN-SNAPSHOT"}
-                ;;org.clojure/clojure {:mvn/version "1.11.1"}
+  {:extra-deps {;;org.clojure/clojure {:mvn/version "1.12.0-CN-SNAPSHOT"}
+                org.clojure/clojure {:mvn/version "1.11.1"}
                 criterium/criterium {:mvn/version "0.4.5"}
                 techascent/tech.ml.dataset {:mvn/version "7.000-beta-34"}
                 ch.qos.logback/logback-classic {:mvn/version "1.1.3"}

--- a/java/ham_fisted/ArrayImmutList.java
+++ b/java/ham_fisted/ArrayImmutList.java
@@ -281,8 +281,8 @@ public class ArrayImmutList
     }
     return Reductions.unreduce(init);
   }
-  public final ISeq seq() { return RT.chunkIteratorSeq(iterator()); }
-  public final ISeq rseq() { return RT.chunkIteratorSeq(riterator()); }
+  public final ISeq seq() { return LazyChunkedSeq.chunkIteratorSeq(iterator()); }
+  public final ISeq rseq() { return LazyChunkedSeq.chunkIteratorSeq(riterator()); }
   public final IPersistentVector cons(Object obj) {
     final int ne = nElems;
     switch(ne){

--- a/java/ham_fisted/IMap.java
+++ b/java/ham_fisted/IMap.java
@@ -66,7 +66,7 @@ public interface IMap extends Map, ITypedReduce, ILookup, IFnDef, Iterable, IMap
       }, init);
   }
   default ISeq seq() {
-    return RT.chunkIteratorSeq(iterator());
+    return LazyChunkedSeq.chunkIteratorSeq(iterator());
   }
   public static class MapKeySet extends AbstractSet implements ITypedReduce, IFnDef, Counted {
     public final IMap data;
@@ -144,7 +144,7 @@ public interface IMap extends Map, ITypedReduce, ILookup, IFnDef, Iterable, IMap
       data.clear();
     }
     public final Iterator iterator() {
-      return data.valIterator(); 
+      return data.valIterator();
     }
     @SuppressWarnings("unchecked")
     public final Spliterator spliterator() {
@@ -164,7 +164,7 @@ public interface IMap extends Map, ITypedReduce, ILookup, IFnDef, Iterable, IMap
 				    ParallelOptions options ) {
       return data.parallelReduction(initValFn, wrapRfn(rfn), mergeFn, options);
     }
-    
+
     @SuppressWarnings("unchecked")
     public void forEach(Consumer c) {
       reduce( new IFnDef() {

--- a/java/ham_fisted/ISet.java
+++ b/java/ham_fisted/ISet.java
@@ -48,7 +48,7 @@ public interface ISet extends Set, ITypedReduce, IFnDef, Counted, Seqable {
     }
     return sz == size();
   }
-  default ISeq seq() { return RT.chunkIteratorSeq(iterator()); }
+  default ISeq seq() { return LazyChunkedSeq.chunkIteratorSeq(iterator()); }
   default boolean isEmpty() { return size() == 0; }
   default Object[] toArray() { return ArrayLists.toArray(this); }
   default Object[] toArray(Object[] d) {

--- a/java/ham_fisted/LazyChunkedSeq.java
+++ b/java/ham_fisted/LazyChunkedSeq.java
@@ -62,7 +62,7 @@ public class LazyChunkedSeq extends ASeq implements IChunkedSeq {
     IChunkedSeq s = lockedUnwrap();
     return s != null ? s.first() : null;
   }
-  public ISeq next() {    
+  public ISeq next() {
     IChunkedSeq s = lockedUnwrap();
     return s != null ? s.next() : null;
   }
@@ -70,7 +70,7 @@ public class LazyChunkedSeq extends ASeq implements IChunkedSeq {
     ISeq rv = next();
     return rv != null ? rv : PersistentList.EMPTY;
   }
-  public IChunk chunkedFirst() {    
+  public IChunk chunkedFirst() {
     IChunkedSeq s = lockedUnwrap();
     return s != null ? s.chunkedFirst() : null;
   }
@@ -83,7 +83,7 @@ public class LazyChunkedSeq extends ASeq implements IChunkedSeq {
     return rv != null ? rv : PersistentList.EMPTY;
   }
 
-  public static IChunkedSeq fromIterator(Iterator i) {
+  public static IChunkedSeq chunkIteratorSeq(Iterator i) {
     if(i.hasNext()) {
       return new LazyChunkedSeq(new IFnDef() {
 	  public Object invoke() {
@@ -91,7 +91,7 @@ public class LazyChunkedSeq extends ASeq implements IChunkedSeq {
 	    int idx;
 	    for(idx = 0; idx < 32 && i.hasNext(); ++idx)
 	      ar[idx] = i.next();
-	    return new ChunkedCons(new ArrayChunk(ar, 0, idx), create(i));
+	    return new ChunkedCons(new ArrayChunk(ar, 0, idx), chunkIteratorSeq(i));
 	  }
 	});
     } else {

--- a/java/ham_fisted/LazyChunkedSeq.java
+++ b/java/ham_fisted/LazyChunkedSeq.java
@@ -1,0 +1,101 @@
+package ham_fisted;
+
+
+import clojure.lang.IFn;
+import clojure.lang.IChunkedSeq;
+import clojure.lang.IChunk;
+import clojure.lang.ASeq;
+import clojure.lang.Util;
+import clojure.lang.PersistentList;
+import clojure.lang.ISeq;
+import clojure.lang.IPersistentMap;
+import clojure.lang.ChunkedCons;
+import clojure.lang.ArrayChunk;
+import java.util.Iterator;
+import java.util.Arrays;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class LazyChunkedSeq extends ASeq implements IChunkedSeq {
+  IFn fn;
+  IChunkedSeq mySeq;
+  Throwable e;
+  volatile Lock lock;
+  public LazyChunkedSeq(IFn fn, IChunkedSeq s, Throwable e, IPersistentMap meta) {
+    super(meta);
+    this.fn = fn;
+    this.mySeq = s;
+    this.e = e;
+    this.lock = new ReentrantLock();
+  }
+  public LazyChunkedSeq(IFn fn) {
+    this(fn, null, null, null);
+  }
+  public LazyChunkedSeq withMeta(IPersistentMap m) { return new LazyChunkedSeq(fn, mySeq, e, m); }
+  IChunkedSeq unlockedUnwrap() {
+    if(fn != null) {
+      try {
+	mySeq = (IChunkedSeq)fn.invoke();
+      } catch (Exception e) {
+	this.e = e;
+      }
+      fn = null;
+      lock = null;
+    }
+    if(this.e != null) throw Util.sneakyThrow(e);
+    return mySeq;
+  }
+  IChunkedSeq lockedUnwrap() {
+    if(mySeq != null) return mySeq;
+    Lock l = lock;
+    if(l != null) {
+      l.lock();
+      try {
+	return unlockedUnwrap();
+      }finally {
+	l.unlock();
+      }
+    }
+    return unlockedUnwrap();
+  }
+  public Object first() {
+    IChunkedSeq s = lockedUnwrap();
+    return s != null ? s.first() : null;
+  }
+  public ISeq next() {    
+    IChunkedSeq s = lockedUnwrap();
+    return s != null ? s.next() : null;
+  }
+  public ISeq more() {
+    ISeq rv = next();
+    return rv != null ? rv : PersistentList.EMPTY;
+  }
+  public IChunk chunkedFirst() {    
+    IChunkedSeq s = lockedUnwrap();
+    return s != null ? s.chunkedFirst() : null;
+  }
+  public ISeq chunkedNext() {
+    IChunkedSeq s = lockedUnwrap();
+    return s != null ? s.chunkedNext() : null;
+  }
+  public ISeq chunkedMore() {
+    ISeq rv = chunkedNext();
+    return rv != null ? rv : PersistentList.EMPTY;
+  }
+
+  public static IChunkedSeq fromIterator(Iterator i) {
+    if(i.hasNext()) {
+      return new LazyChunkedSeq(new IFnDef() {
+	  public Object invoke() {
+	    Object[] ar = new Object[32];
+	    int idx;
+	    for(idx = 0; idx < 32 && i.hasNext(); ++idx)
+	      ar[idx] = i.next();
+	    return new ChunkedCons(new ArrayChunk(ar, 0, idx), create(i));
+	  }
+	});
+    } else {
+      return null;
+    }
+  }
+}

--- a/java/ham_fisted/MapForward.java
+++ b/java/ham_fisted/MapForward.java
@@ -107,7 +107,7 @@ public class MapForward<K,V>
     return getOrDefault(arg1, (V)notFound);
   }
   public ISeq seq() {
-    return RT.chunkIteratorSeq(iterator());
+    return LazyChunkedSeq.chunkIteratorSeq(iterator());
   }
   public IPersistentMap meta() { return meta; }
   public MapForward<K,V> withMeta(IPersistentMap m) { return new MapForward<K,V>(ht, m); }

--- a/java/ham_fisted/PartitionByInner.java
+++ b/java/ham_fisted/PartitionByInner.java
@@ -87,7 +87,7 @@ public class PartitionByInner implements ITypedReduce, Iterator, Seqable, IDeref
     if(!lastVValid) throw new NoSuchElementException();
     return advance();
   }
-  public ISeq seq() { return RT.chunkIteratorSeq(this); }
+  public ISeq seq() { return LazyChunkedSeq.chunkIteratorSeq(this); }
   public Object deref() {
     if(hasNext())
       reduce(new IFnDef() { public Object invoke(Object acc, Object v) { return v; } }, null);

--- a/java/ham_fisted/Ranges.java
+++ b/java/ham_fisted/Ranges.java
@@ -81,7 +81,7 @@ public class Ranges {
       ChunkedList.sublistCheck(sidx, eidx, nElems);
       return new LongRange(start + sidx*step, start + eidx*step, step, meta);
     }
-    public ISeq seq() { return new SublistSeq(this, 0, null); }
+    public ISeq seq() { return inplaceSublistSeq(); }
     public LongMutList subList(int sidx, int eidx) {
       return subList((long)sidx, (long)eidx);
     }
@@ -186,7 +186,7 @@ public class Ranges {
 				   " size: " + String.valueOf(sz));
       return start + step*idx;
     }
-    public ISeq seq() { return new SublistSeq(this, 0, null); }
+    public ISeq seq() { return inplaceSublistSeq(); }
     public double getDouble(int idx) { return lgetDouble(idx); }
     public int[] toIntArray() {
       final int st = RT.intCast(step);

--- a/java/ham_fisted/Transformables.java
+++ b/java/ham_fisted/Transformables.java
@@ -454,14 +454,68 @@ public class Transformables {
     public MapIterable withMeta(IPersistentMap m) {
       return new MapIterable(this, m);
     }
-    public Object reduce(IFn fn) {
-      return Reductions.iterReduce(this, fn);
-    }
-    public Object reduce(IFn rfn, Object init) {
-      if(iterables.length == 1)
-	return singleMapReduce(iterables[0], rfn, fn, init);
-      else
-	return Reductions.iterReduce(this, init, rfn);
+    public Object reduce(IFn rfn, Object acc) {
+      final int nLists = iterables.length;
+      if(nLists == 1) {
+	return singleMapReduce(iterables[0], rfn, fn, acc);
+      } else {
+	final Iterator[] iterators = new Iterator[nLists];
+	for(int idx = 0; idx < nLists; ++idx)
+	  iterators[idx] = toIterable(iterables[idx]).iterator();
+	switch(iterables.length) {
+	case 2: {
+	  final Iterator l = iterators[0];
+	  final Iterator r = iterators[1];
+	  while(l.hasNext() && r.hasNext()) {
+	    acc = rfn.invoke(acc, fn.invoke(l.next(), r.next()));
+	    if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	  }
+	  break;
+	}
+	case 3: {
+	  final Iterator x = iterators[0];
+	  final Iterator y = iterators[1];
+	  final Iterator z = iterators[2];
+	  while(x.hasNext() && y.hasNext() && z.hasNext()) {
+	    acc = rfn.invoke(acc, fn.invoke(x.next(), y.next(), z.next()));
+	    if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	  }
+	  break;
+	}
+	case 4: {
+	  final Iterator x = iterators[0];
+	  final Iterator y = iterators[1];
+	  final Iterator z = iterators[2];
+	  final Iterator w = iterators[3];
+	  while(x.hasNext() && y.hasNext() && z.hasNext() && w.hasNext()) {
+	    acc = rfn.invoke(acc, fn.invoke(x.next(), y.next(), z.next(), w.next()));
+	    if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	  }
+	  break;
+	}		
+	default: {
+	  boolean hn = true;
+	  for(int idx = 0; idx < nLists && hn; ++idx) {
+	    hn = hn && iterators[idx].hasNext();
+	  }
+	  if(hn) {
+	    final Object[] args = new Object[nLists];
+	    final ISeq argSeq = ArraySeq.create(args);
+	    while(hn) {
+	      for(int idx = 0; idx < nLists && hn; ++idx) {
+		args[idx] = iterators[idx].next();
+	      }
+	      acc = rfn.invoke(acc, fn.applyTo(argSeq));
+	      if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	      for(int idx = 0; idx < nLists && hn; ++idx) {
+		hn = hn && iterators[idx].hasNext();
+	      }
+	    }
+	  }
+	}
+	}
+      }
+      return acc;
     }
     public Object parallelReduction(IFn initValFn, IFn rfn, IFn mergeFn,
 				    ParallelOptions options) {
@@ -973,24 +1027,61 @@ public class Transformables {
     final List[] lists;
     final IFn fn;
     final IPersistentMap meta;
+    final IFn.LO getter;
     public MapList(IFn _fn, IPersistentMap _meta, List... _lists) {
-      final int ll = _lists.length;
-      if(ll == 0)
+      final int nLists = _lists.length;
+      if(nLists == 0)
 	nElems = 0;
       else {
 	int ne = _lists[0].size();
-	for(int idx = 1; idx < ll; ++idx)
+	for(int idx = 1; idx < nLists; ++idx)
 	  ne = Math.min(ne, _lists[idx].size());
 	nElems = ne;
       }
       lists = _lists;
       fn = _fn;
       meta = _meta;
+      IFn.LO getter = null;
+      final List[] ll = lists;
+      switch(nLists) {
+      case 1: getter = new IFnDef.LO() {
+	  public Object invokePrim(long idx) { return fn.invoke(ll[0].get((int)idx));
+	  } };
+	break;
+      case 2:  getter = new IFnDef.LO() {
+	  public Object invokePrim(long idx) { return fn.invoke(ll[0].get((int)idx), ll[1].get((int)idx));
+	  } };
+	break;
+      case 3:  getter = new IFnDef.LO() {
+	  public Object invokePrim(long lidx) { final int idx = (int)lidx; return fn.invoke(ll[0].get(idx), ll[1].get(idx), ll[2].get(idx));
+	  } };
+	break;
+      case 4:
+	getter = new IFnDef.LO() {
+	  public Object invokePrim(long lidx) { final int idx = (int)lidx; return fn.invoke(ll[0].get(idx),
+											    ll[1].get(idx),
+											    ll[2].get(idx),
+											    ll[3].get(idx));
+	  } };
+	break;
+      default:
+	getter = new IFnDef.LO() {
+	    public Object invokePrim(long lidx) {
+	      final int idx = (int)lidx;
+	      Object[] args = new Object[nLists];
+	      for (int aidx = 0; aidx < nLists; ++aidx)
+		args[aidx] = lists[aidx].get(idx);
+	      return fn.applyTo(ArraySeq.create(args));
+	    }
+	  };
+      }
+      this.getter = getter;
     }
     public MapList(MapList other, IPersistentMap m) {
       nElems = other.nElems;
       lists = other.lists;
       fn = other.fn;
+      getter = other.getter;
       meta = m;
     }
     public static IMutList create(IFn fn, IPersistentMap meta, List... lists) {
@@ -1012,19 +1103,8 @@ public class Transformables {
 	idx += nElems;
       if(idx < 0 || idx >= nElems)
 	throw new RuntimeException("Index out of range.");
-      final List[] ll = lists;
-      final int ls = ll.length;
-      switch(ls) {
-      case 1: return fn.invoke(ll[0].get(idx));
-      case 2: return fn.invoke(ll[0].get(idx), ll[1].get(idx));
-      case 3: return fn.invoke(ll[0].get(idx), ll[1].get(idx), ll[2].get(idx));
-      case 4: return fn.invoke(ll[0].get(idx), ll[1].get(idx), ll[2].get(idx), ll[3].get(idx));
-      default:
-	Object[] args = new Object[ls];
-	for (int aidx = 0; aidx < ls; ++aidx)
-	  args[aidx] = lists[aidx].get(idx);
-	return fn.applyTo(ArraySeq.create(args));
-      }
+      return getter.invokePrim(idx);
+      
     }
     public Object reduce(IFn rfn, Object acc) {
       final int ne = nElems;
@@ -1032,9 +1112,25 @@ public class Transformables {
       final int ls = ll.length;
       switch(ls) {
       case 1: return Reductions.serialReduction( mapReducer(rfn, this.fn), acc, ll[0] );
-      case 2: return IMutList.super.reduce(rfn, acc);
-      case 3: return IMutList.super.reduce(rfn, acc);
-      case 4: return IMutList.super.reduce(rfn, acc);
+      case 2:
+	for (int idx = 0; idx < ne; ++idx) {
+	  acc = rfn.invoke(acc, fn.invoke(lists[0].get(idx), lists[1].get(idx)));
+	  if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	}
+	return acc;
+      case 3:
+	for (int idx = 0; idx < ne; ++idx) {
+	  acc = rfn.invoke(acc, fn.invoke(lists[0].get(idx), lists[1].get(idx), lists[2].get(idx)));
+	  if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	}
+	return acc;
+      case 4:
+	for (int idx = 0; idx < ne; ++idx) {
+	  acc = rfn.invoke(acc, fn.invoke(lists[0].get(idx), lists[1].get(idx),
+					  lists[2].get(idx), lists[3].get(idx)));
+	  if(RT.isReduced(acc)) return ((IDeref)acc).deref();
+	}
+	return acc;
       }
       //fallthrough
       final Object[] args = new Object[ls];
@@ -1042,7 +1138,7 @@ public class Transformables {
       for(int oidx = 0; oidx < ne; ++oidx) {
 	for (int aidx = 0; aidx < ls; ++aidx)
 	  args[aidx] = lists[aidx].get(oidx);
-	acc = rfn.applyTo(arglist);
+	acc = rfn.invoke(acc, fn.applyTo(arglist));
 	if(RT.isReduced(acc))
 	  return ((IDeref)acc).deref();
       }

--- a/java/ham_fisted/Transformables.java
+++ b/java/ham_fisted/Transformables.java
@@ -354,7 +354,7 @@ public class Transformables {
     default void forEach(Consumer c) {
       ITypedReduce.super.forEach(c);
     }
-    default ISeq seq() { return RT.chunkIteratorSeq(iterator()); }
+    default ISeq seq() { return LazyChunkedSeq.chunkIteratorSeq(iterator()); }
   }
 
   public static class MapIterable
@@ -442,7 +442,7 @@ public class Transformables {
       }
     }
     public ISeq seq() {
-      return RT.chunkIteratorSeq(iterator());
+      return LazyChunkedSeq.chunkIteratorSeq(iterator());
     }
     public boolean equals(Object o) { return equiv(o); }
     public int hashCode(){ return hasheq(); }
@@ -492,7 +492,7 @@ public class Transformables {
 	    if(RT.isReduced(acc)) return ((IDeref)acc).deref();
 	  }
 	  break;
-	}		
+	}
 	default: {
 	  boolean hn = true;
 	  for(int idx = 0; idx < nLists && hn; ++idx) {
@@ -644,7 +644,7 @@ public class Transformables {
     public int hashCode(){ return hasheq(); }
     public boolean equals(Object o) { return equiv(o); }
     public ISeq seq() {
-      return RT.chunkIteratorSeq(iterator());
+      return LazyChunkedSeq.chunkIteratorSeq(iterator());
     }
     public IMapable filter(IFn nfn) {
       return new FilterIterable(PredFn.create(pred, nfn), meta(), src);
@@ -810,7 +810,7 @@ public class Transformables {
       newd[dlen] = _iters;
       return new CatIterable(meta(), newd);
     }
-    public ISeq seq() { return RT.chunkIteratorSeq(iterator()); }
+    public ISeq seq() { return LazyChunkedSeq.chunkIteratorSeq(iterator()); }
     public IPersistentMap meta() { return meta; }
     public CatIterable withMeta(IPersistentMap m) {
       return new CatIterable(this, m);
@@ -1104,7 +1104,7 @@ public class Transformables {
       if(idx < 0 || idx >= nElems)
 	throw new RuntimeException("Index out of range.");
       return getter.invokePrim(idx);
-      
+
     }
     public Object reduce(IFn rfn, Object acc) {
       final int ne = nElems;
@@ -1226,7 +1226,7 @@ public class Transformables {
       return seq.updateAndGet(new UnaryOperator<ISeq>() {
 	  public ISeq apply(ISeq v) {
 	    if(v != null) return v;
-	    return src instanceof Seqable ? ((Seqable)src).seq() : RT.chunkIteratorSeq(src.iterator());
+	    return src instanceof Seqable ? ((Seqable)src).seq() : LazyChunkedSeq.chunkIteratorSeq(src.iterator());
 	  }
 	});
     }

--- a/src/ham_fisted/lazy_caching.clj
+++ b/src/ham_fisted/lazy_caching.clj
@@ -1,44 +1,160 @@
 (ns ham-fisted.lazy-caching
-  (:require [ham-fisted.lazy-noncaching :as lzn])
-  (:import [java.util RandomAccess]
-           [ham_fisted Transformables$CachingIterable Transformables$CachingList])
+  (:require [ham-fisted.lazy-noncaching :as lznc])
+  (:import [java.util RandomAccess List Iterator]
+           [ham_fisted Transformables$CachingIterable Transformables$CachingList
+            ArrayLists ArrayHelpers ArrayLists$ObjectArrayList]
+           [clojure.lang ISeq ArraySeq IFn])
   (:refer-clojure :exclude [map filter concat repeatedly]))
 
+(defn- seq-map-recur
+  ([f ^ISeq c1 ^ISeq c2]
+   (when (and c1 c2)
+     (cons (f (.first c1) (.first c2))
+           (lazy-seq (seq-map-recur f (.next c1) (.next c2))))))
+  ([f ^ISeq c1 ^ISeq c2 ^ISeq c3]
+   (when (and c1 c2 c3)
+     (cons (f (.first c1) (.first c2) (.first c3))
+           (lazy-seq (seq-map-recur f (.next c1) (.next c2) (.next c3))))))
+  ([f ^ISeq c1 ^ISeq c2 ^ISeq c3 ^ISeq c4]
+   (when (and c1 c2 c3 c4)
+     (cons (f (.first c1) (.first c2) (.first c3) (.first c4))
+           (lazy-seq (seq-map-recur f (.next c1) (.next c2) (.next c3) (.next c4))))))
+  ([f ^List cs]
+   (let [ncs (.size cs)
+         args (ArrayLists/objectArray ncs)         
+         next? (loop [idx 0 next? true]
+                 (if (< idx ncs)
+                   (let [^ISeq c (.get cs (unchecked-int idx))
+                         _ (ArrayHelpers/aset args (unchecked-int idx) (.first c))
+                         c (.next c)]               
+                     (.set cs (unchecked-int idx) c)
+                     (recur (unchecked-inc idx) (and next? c)))
+                   next?))]
+     (cons (.applyTo ^IFn f (ArraySeq/create args))
+           (when next? 
+             (lazy-seq (seq-map-recur f cs)))))))
 
-(defn cached
-  [item]
-  (let [item (lzn/->collection item)]
-    (if (instance? RandomAccess item)
-      (Transformables$CachingList. item nil)
-      (Transformables$CachingIterable. item nil))))
+(defn- seq-map
+  ([f arg] (clojure.core/map f arg))
+  ([f c1 c2]
+   (let [^ISeq c1 (seq c1)
+         ^ISeq c2 (seq c2)]
+     (if (and c1 c2)
+       (seq-map-recur f c1 c2)
+       '())))
+  ([f c1 c2 c3]
+   (let [^ISeq c1 (seq c1)
+         ^ISeq c2 (seq c2)
+         ^ISeq c3 (seq c3)]
+     (if (and c1 c2 c3)
+       (seq-map-recur f c1 c2 c3)
+       '())))
+  ([f c1 c2 c3 c4]
+   (let [^ISeq c1 (seq c1)
+         ^ISeq c2 (seq c2)
+         ^ISeq c3 (seq c3)
+         ^ISeq c4 (seq c4)]
+     (if (and c1 c2 c3 c4)
+       (seq-map-recur f c1 c2 c3 c4)
+       '())))
+  ([f c1 c2 c3 c4 args]
+   (let [cs (ArrayLists$ObjectArrayList.)
+         c1 (seq c1)
+         c2 (seq c2)
+         c3 (seq c3)
+         c4 (seq c4)]
+     (if (and c1 c2 c3 c4)
+       (do 
+         (.add cs c1)
+         (.add cs c2)
+         (.add cs c3)
+         (.add cs c4)
+         (let [all-valid? 
+               (reduce (fn [acc v]
+                         (if-let [s (seq v)]
+                           (do (.add cs s)
+                               acc)
+                           (reduced false)))
+                       true
+                       args)]
+           (if all-valid?
+             (seq-map-recur f cs)
+             '())))
+       '()))))
 
 
 (defn map
-  ([f arg]
-   (-> (lzn/map f arg)
-       (cached)))
-  ([f arg & args]
-   (-> (apply lzn/map f arg args)
-       (cached))))
+  ([f arg] (clojure.core/map f arg))
+  ([f c1 c2] (->> (lznc/map f c1 c2) (seq)))
+  ([f c1 c2 c3] (seq-map f c1 c2 c3))
+  ([f c1 c2 c3 c4] (seq-map f c1 c2 c3 c4))
+  ([f c1 c2 c3 c4 & args] (seq-map f c1 c2 c3 c4 args)))
+
+
+(defn- seq-tuple-map
+  ([f ^ISeq c1 ^ISeq c2]
+   (let [args (ArrayLists/objectArray 2)
+         _ (ArrayHelpers/aset args (unchecked-int 0) (.first c1))
+         _ (ArrayHelpers/aset args (unchecked-int 1) (.first c2))
+         c1 (.next c1)
+         c2 (.next c2)]
+     (cons (f (ArrayLists/toList args))
+           (when (and c1 c2)
+             (lazy-seq (seq-tuple-map f c1 c2))))))
+  ([f ^List cs]
+   (let [n-args (.size cs)
+         args (ArrayLists/objectArray n-args)
+         next? (loop [idx 0
+                      next? true]
+                 (if (< idx n-args)
+                   (let [^ISeq c (.get cs (unchecked-int idx))
+                         _ (ArrayHelpers/aset args (unchecked-int idx) (.first c))
+                         c (.next c)]
+                     (.set cs (unchecked-int idx) c)
+                     (recur (unchecked-inc idx) (and next? c)))
+                   next?))]
+     (cons (f (ArrayLists/toList args))
+           (when next?
+             (lazy-seq (seq-tuple-map f cs)))))))
+
+
+(defn tuple-map
+  "f always receives a single tuple argument.  This is *far* faster for larger argument lists."
+  ([f arg] (clojure.core/map #(f [%]) arg))
+  ([f c1 c2]
+   (let [c1 (seq c1)
+         c2 (seq c2)]
+     (if (and c1 c2)
+       (seq-tuple-map f c1 c2)
+       '())))
+  ([f c1 c2 & args]
+   (let [args (doto  (ArrayLists$ObjectArrayList.)
+                (.add (seq c1))
+                (.add (seq c2))
+                (.addAll (lznc/map seq args)))]
+     (if (lznc/every? identity args)
+       (seq-tuple-map f args)
+       '()))))
+
 
 
 (defn filter
   [pred coll]
-  (-> (lzn/filter pred coll)
-      (cached)))
+  (-> (lznc/filter pred coll)
+      (seq)))
 
 
 (defn concat
   ([] nil)
   ([a] a)
-  ([a b] (-> (lzn/concat a b)
-             (cached)))
+  ([a b] (->> (lznc/concat a b)
+              (seq)))
   ([a b & args]
-   (-> (apply lzn/concat a b args)
-       (cached))))
+   (-> (apply lznc/concat a b args)
+       (seq))))
 
 
 (defn repeatedly
   ([f] (clojure.core/repeatedly f))
-  ([n f] (-> (lzn/repeatedly n f)
-             (cached))))
+  ([n f] (-> (lznc/repeatedly n f)
+             (seq))))

--- a/src/ham_fisted/lazy_caching.clj
+++ b/src/ham_fisted/lazy_caching.clj
@@ -2,39 +2,80 @@
   (:require [ham-fisted.lazy-noncaching :as lznc])
   (:import [java.util RandomAccess List Iterator]
            [ham_fisted Transformables$CachingIterable Transformables$CachingList
-            ArrayLists ArrayHelpers ArrayLists$ObjectArrayList]
-           [clojure.lang ISeq ArraySeq IFn])
+            ArrayLists ArrayHelpers ArrayLists$ObjectArrayList LazyChunkedSeq]
+           [clojure.lang ISeq ArraySeq IFn ChunkedCons ArrayChunk])
   (:refer-clojure :exclude [map filter concat repeatedly]))
+
+
+(defmacro lazy-chunked-seq
+  [chunked-cons-code]
+  `(LazyChunkedSeq. (fn [] ~chunked-cons-code)))
+
 
 (defn- seq-map-recur
   ([f ^ISeq c1 ^ISeq c2]
-   (when (and c1 c2)
-     (cons (f (.first c1) (.first c2))
-           (lazy-seq (seq-map-recur f (.next c1) (.next c2))))))
+   (let [chunk-data (ArrayLists/objectArray 32)]
+     (loop [c1 c1
+            c2 c2
+            idx 0]
+       (if (and c1 c2 (< idx 32))
+         (do
+           (ArrayHelpers/aset chunk-data idx (f (.first c1) (.first c2)))
+           (recur (.next c1) (.next c2) (unchecked-inc idx)))
+         (ChunkedCons. (ArrayChunk. chunk-data 0 idx)
+                       (when (and c1 c2)
+                         (lazy-chunked-seq (seq-map-recur f c1 c2))))))))
   ([f ^ISeq c1 ^ISeq c2 ^ISeq c3]
-   (when (and c1 c2 c3)
-     (cons (f (.first c1) (.first c2) (.first c3))
-           (lazy-seq (seq-map-recur f (.next c1) (.next c2) (.next c3))))))
+   (let [chunk-data (ArrayLists/objectArray 32)]
+     (loop [c1 c1
+            c2 c2
+            c3 c3
+            idx 0]
+       (if (and c1 c2 c3 (< idx 32))
+         (do
+           (ArrayHelpers/aset chunk-data idx (f (.first c1) (.first c2) (.first c3)))
+           (recur (.next c1) (.next c2) (.next c3 )(unchecked-inc idx)))
+         (ChunkedCons. (ArrayChunk. chunk-data 0 idx)
+                       (when (and c1 c2 c3)
+                         (lazy-chunked-seq (seq-map-recur f c1 c2 c3))))))))
   ([f ^ISeq c1 ^ISeq c2 ^ISeq c3 ^ISeq c4]
-   (when (and c1 c2 c3 c4)
-     (cons (f (.first c1) (.first c2) (.first c3) (.first c4))
-           (lazy-seq (seq-map-recur f (.next c1) (.next c2) (.next c3) (.next c4))))))
+   (let [chunk-data (ArrayLists/objectArray 32)]
+     (loop [c1 c1
+            c2 c2
+            c3 c3
+            c4 c4
+            idx 0]
+       (if (and c1 c2 c3 c4 (< idx 32))
+         (do
+           (ArrayHelpers/aset chunk-data idx (f (.first c1) (.first c2) (.first c3) (.first c4)))
+           (recur (.next c1) (.next c2) (.next c3) (.next c4) (unchecked-inc idx)))
+         (ChunkedCons. (ArrayChunk. chunk-data 0 idx)
+                       (when (and c1 c2 c3 c4)
+                         (lazy-chunked-seq (seq-map-recur f c1 c2 c3 c4))))))))
   ([f ^List cs]
-   (let [ncs (.size cs)
-         args (ArrayLists/objectArray ncs)         
-         next? (loop [idx 0 next? true]
-                 (if (< idx ncs)
-                   (let [^ISeq c (.get cs (unchecked-int idx))
-                         _ (ArrayHelpers/aset args (unchecked-int idx) (.first c))
-                         c (.next c)]               
-                     (.set cs (unchecked-int idx) c)
-                     (recur (unchecked-inc idx) (and next? c)))
-                   next?))]
-     (cons (.applyTo ^IFn f (ArraySeq/create args))
-           (when next? 
-             (lazy-seq (seq-map-recur f cs)))))))
+   (let [chunk-data (ArrayLists/objectArray 32)
+         ncs (.size cs)
+         args (ArrayLists/objectArray ncs)
+         [cidx next?]
+         (loop [cidx 0
+                next? true]
+           (if (and next? (< cidx 32))
+             (let [next? (loop [idx 0 next? true]
+                           (if (< idx ncs)
+                             (let [^ISeq c (.get cs (unchecked-int idx))
+                                   _ (ArrayHelpers/aset args (unchecked-int idx) (.first c))
+                                   c (.next c)]
+                               (.set cs (unchecked-int idx) c)
+                               (recur (unchecked-inc idx) (and next? c)))
+                             next?))]
+               (ArrayHelpers/aset chunk-data cidx (.applyTo ^IFn f (ArraySeq/create args)))
+               (recur (unchecked-inc cidx) next?))
+             [cidx next?]))]
+     (ChunkedCons. (ArrayChunk. chunk-data 0 cidx)
+                   (when next?
+                     (lazy-chunked-seq (seq-map-recur f cs)))))))
 
-(defn- seq-map
+(defn ^:no-doc seq-map
   ([f arg] (clojure.core/map f arg))
   ([f c1 c2]
    (let [^ISeq c1 (seq c1)
@@ -64,12 +105,12 @@
          c3 (seq c3)
          c4 (seq c4)]
      (if (and c1 c2 c3 c4)
-       (do 
+       (do
          (.add cs c1)
          (.add cs c2)
          (.add cs c3)
          (.add cs c4)
-         (let [all-valid? 
+         (let [all-valid?
                (reduce (fn [acc v]
                          (if-let [s (seq v)]
                            (do (.add cs s)
@@ -85,7 +126,7 @@
 
 (defn map
   ([f arg] (clojure.core/map f arg))
-  ([f c1 c2] (->> (lznc/map f c1 c2) (seq)))
+  ([f c1 c2] (seq-map f c1 c2))
   ([f c1 c2 c3] (seq-map f c1 c2 c3))
   ([f c1 c2 c3 c4] (seq-map f c1 c2 c3 c4))
   ([f c1 c2 c3 c4 & args] (seq-map f c1 c2 c3 c4 args)))

--- a/src/ham_fisted/lazy_noncaching.clj
+++ b/src/ham_fisted/lazy_noncaching.clj
@@ -253,7 +253,7 @@
 
 (defn map-reducible
   "Map a function over r - r need only be reducible.  Returned value does not implement
-  seq but is countable when r is countable countable."
+  seq but is countable when r is countable."
   [f r]
   (if-let [c (constant-count r)]
     (reify
@@ -268,13 +268,101 @@
         (Reductions/serialReduction (Transformables/typedMapReducer rfn f) acc r)))))
 
 
+(defn tuple-map
+  "Lazy nonaching map but f simply gets a single random-access list of arguments.
+  The argument list may be mutably updated between calls."
+  ([f c1]
+   (let [rdc (fn [rfn acc] (reduce c1 (fn [acc v] (rfn acc (f [v])))))]
+     (if-let [c1 (as-random-access c1)]
+       (reify IMutList
+         (size [this] (.size c1))
+         (get [this idx] (f [(.get c1 idx)]))
+         (subList [this sidx eidx]
+           (tuple-map f (.subList c1 sidx eidx)))
+         (reduce [this rfn acc]
+           (rdc rfn acc)))
+       (reify
+         Iterable
+         (iterator [this]
+           (let [citer (.iterator (->iterable c1))]
+             (reify Iterator
+               (hasNext [this] (.hasNext citer))
+               (next [this] (f [(.next citer)])))))
+         Seqable
+         (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+         ITypedReduce
+         (reduce [this rfn acc]
+           (rdc rfn acc))))))
+  ([f c1 c2]
+   (let [c1 (->iterable c1)
+         c2 (->iterable c2)]
+     (reify
+       Iterable
+       (iterator [this]
+         (let [c1-iter (.iterator c1)
+               c2-iter (.iterator c2)]
+           (reify Iterator
+             (hasNext [this] (and (.hasNext c1-iter)
+                                  (.hasNext c2-iter)))
+             (next [this]
+               (f [(.next c1-iter) (.next c2-iter)])))))
+       Seqable
+       (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+       ITypedReduce
+       (reduce [this rfn acc]
+         (Reductions/iterReduce this acc rfn)))))
+  ([f c1 c2 & cs]
+   (let [cs (doto (ArrayLists$ObjectArrayList.)
+              (.add c1)
+              (.add c2)
+              (.addAll cs))
+         nargs (.size cs)
+         next-fn (fn next-fn [iters ^objects args]
+                   (loop [idx 0]
+                     (if (< idx nargs)
+                       (let [^Iterator iter (iters idx)]
+                         (if (.hasNext iter)
+                           (do 
+                             (ArrayHelpers/aset args (unchecked-int idx) (.next iter))
+                             (recur (unchecked-inc idx)))
+                           false))
+                       true)))
+         rdc (fn [rfn acc]
+               (let [iters (mapv #(.iterator (->iterable %)) cs)]
+                 (loop [acc acc
+                        args (ArrayLists/objectArray nargs)
+                        next? (next-fn iters args)]
+                   (if next? 
+                     (let [acc (rfn acc (f (ArrayLists/toList ^objects args)))]
+                       (if (reduced? acc)
+                         (deref acc)
+                         (let [args (ArrayLists/objectArray nargs)]
+                           (recur acc args (next-fn iters args)))))
+                     acc))))]
+     (reify
+       Iterable
+       (iterator [this]
+         (let [args (ArrayLists/objectArray nargs)
+               argvec (ArrayLists/toList args)
+               iters (mapv #(.iterator (->iterable %)) cs)]
+           (reify
+             Iterator
+             (hasNext [this] (next-fn iters args))
+             (next [this] (f argvec)))))
+       Seqable
+       (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+       ITypedReduce
+       (reduce [this rfn acc]
+         (rdc rfn acc))))))
+
+
 (defn concat
   ([] PersistentList/EMPTY)
   ([a] (if a a PersistentList/EMPTY))
   ([a & args]
    (if (instance? Transformables$IMapable a)
-    (.cat ^Transformables$IMapable a args)
-    (Transformables$CatIterable. (cons a args)))))
+     (.cat ^Transformables$IMapable a args)
+     (Transformables$CatIterable. (cons a args)))))
 
 
 (pp/implement-tostring-print Transformables$CatIterable)

--- a/src/ham_fisted/lazy_noncaching.clj
+++ b/src/ham_fisted/lazy_noncaching.clj
@@ -20,7 +20,7 @@
             DoubleMutList ReindexList Transformables$IndexedMapper
             IFnDef$OLO IFnDef$ODO Reductions Reductions$IndexedAccum
             IFnDef$OLOO ArrayHelpers ITypedReduce PartitionByInner Casts
-            IMutList]
+            IMutList LazyChunkedSeq]
            [java.lang.reflect Array]
            [it.unimi.dsi.fastutil.ints IntArrays]
            [java.util RandomAccess Collection Map List Random Set Iterator]
@@ -289,7 +289,7 @@
                (hasNext [this] (.hasNext citer))
                (next [this] (f [(.next citer)])))))
          Seqable
-         (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+         (seq [this] (LazyChunkedSeq/chunkIteratorSeq (.iterator this)))
          ITypedReduce
          (reduce [this rfn acc]
            (rdc rfn acc))))))
@@ -307,7 +307,7 @@
              (next [this]
                (f [(.next c1-iter) (.next c2-iter)])))))
        Seqable
-       (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+       (seq [this] (LazyChunkedSeq/chunkIteratorSeq (.iterator this)))
        ITypedReduce
        (reduce [this rfn acc]
          (Reductions/iterReduce this acc rfn)))))
@@ -322,7 +322,7 @@
                      (if (< idx nargs)
                        (let [^Iterator iter (iters idx)]
                          (if (.hasNext iter)
-                           (do 
+                           (do
                              (ArrayHelpers/aset args (unchecked-int idx) (.next iter))
                              (recur (unchecked-inc idx)))
                            false))
@@ -332,7 +332,7 @@
                  (loop [acc acc
                         args (ArrayLists/objectArray nargs)
                         next? (next-fn iters args)]
-                   (if next? 
+                   (if next?
                      (let [acc (rfn acc (f (ArrayLists/toList ^objects args)))]
                        (if (reduced? acc)
                          (deref acc)
@@ -350,7 +350,7 @@
              (hasNext [this] (next-fn iters args))
              (next [this] (f argvec)))))
        Seqable
-       (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+       (seq [this] (LazyChunkedSeq/chunkIteratorSeq (.iterator this)))
        ITypedReduce
        (reduce [this rfn acc]
          (rdc rfn acc))))))
@@ -1066,7 +1066,7 @@ user> (hamf/sum-fast (lznc/cartesian-map
                      (set! (.-val ib) (.iterator b))))
                  rv)))))
        Seqable
-       (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+       (seq [this] (LazyChunkedSeq/chunkIteratorSeq (.iterator this)))
        ITypedReduce
        (reduce [this rfn acc]
          (reducer rfn acc)))))
@@ -1122,7 +1122,7 @@ user> (hamf/sum-fast (lznc/cartesian-map
                        (set! (.-val values-valid?) false))))
                  rv)))))
        Seqable
-       (seq [this] (RT/chunkIteratorSeq (.iterator this)))
+       (seq [this] (LazyChunkedSeq/chunkIteratorSeq (.iterator this)))
        ITypedReduce
        (reduce [this rfn acc]
          (let [values (ArrayLists/objectArray (unchecked-int nargs))


### PR DESCRIPTION
Faster lazy caching implementations of map and various details around chunking.  

Turns out clojure.core/map is really inefficient when the sequence isn't itself chunked or what there are more than one collection passed in.  The implementation in lazy-caching is many times faster I think in every situation - especially the latest versions which always do chunking but chunking is such a minefield - you are better off going with lazy-noncaching IMO as it is still element-by-element processing in most situations.

That being said it is important that contains to provide chunking seqs when possible to play well with the various functions in clojure core.  