### PR TITLE
feat: add kaocha tests runner, run code coverage, bump deps, test multiple JDKs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,19 +15,49 @@ jobs:
            ~/.m2/repository
            ~/.deps.clj
         key: cljdeps-${{ hashFiles('deps.edn') }}
-    - name: Java setup
-      uses: actions/setup-java@v3
+    - name: Mise-en-place setup
+      uses: jdx/mise-action@v2
       with:
-        distribution: 'temurin'
-        java-version: '8'
+        install: true
+        cache: true
     - name: Setup Clojure
       uses: DeLaGuardo/setup-clojure@12.1
       with:
         cli: 1.11.1.1413
     - name: Run clojure linter
-      run: scripts/lint
-    - name: Run automated tests
-      run: scripts/run-tests
+      run: |
+        mise use java@corretto-8
+        scripts/lint
+    - name: Run automated tests - Java 8
+      run: |
+        mise use java@corretto-8
+        java -version
+        scripts/run-tests
+    - name: Run automated tests - Java 11
+      run: |
+        mise use java@corretto-11
+        java -version
+        scripts/run-tests
+    - name: Run automated tests - Java 17
+      run: |
+        mise use java@corretto-17
+        java -version
+        scripts/run-tests
+    - name: Run automated tests - Java 19
+      run: |
+        mise use java@corretto-19
+        java -version
+        scripts/run-tests
+    - name: Run automated tests - Java 21
+      run: |
+        mise use java@corretto-21
+        java -version
+        scripts/run-tests
+    - name: Run automated tests - Java 22
+      run: |
+        mise use java@corretto-22
+        java -version
+        scripts/run-tests
     - name: Setup LCOV
       uses: hrishikesh-kadam/setup-lcov@v1
     - name: Report code coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,16 @@ jobs:
       run: scripts/lint
     - name: Run automated tests
       run: scripts/run-tests
+    - name: Setup LCOV
+      uses: hrishikesh-kadam/setup-lcov@v1
+    - name: Report code coverage
+      uses: zgosalvez/github-actions-report-lcov@v3
+      with:
+        coverage-files: target/coverage/lcov.info
+        minimum-coverage: 0
+        artifact-name: code-coverage-report
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        update-comment: false
     - name: Cache dependencies
       uses: actions/cache@v3
       with:

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "corretto-8"

--- a/deps.edn
+++ b/deps.edn
@@ -1,40 +1,38 @@
 {:paths ["src" "resources" "target/classes"]
- :deps {it.unimi.dsi/fastutil-core {:mvn/version "8.5.8"}
+ :deps {it.unimi.dsi/fastutil-core {:mvn/version "8.5.14"}
         com.github.ben-manes.caffeine/caffeine {:mvn/version "2.9.3"}}
 
  :aliases
  {;; Run with clj -T:build function-in-build
   :dev
   {:extra-deps {;;org.clojure/clojure {:mvn/version "1.12.0-CN-SNAPSHOT"}
-                org.clojure/clojure {:mvn/version "1.11.1"}
-                criterium/criterium {:mvn/version "0.4.5"}
-                techascent/tech.ml.dataset {:mvn/version "7.000-beta-34"}
+                org.clojure/clojure {:mvn/version "1.11.4"}
+                criterium/criterium {:mvn/version "0.4.6"}
+                techascent/tech.ml.dataset {:mvn/version "7.032"}
                 ch.qos.logback/logback-classic {:mvn/version "1.1.3"}
                 kixi/stats {:mvn/version "0.5.5"}
-                org.clojure/data.int-map {:mvn/version "1.2.0"}
-                techascent/tech.viz {:mvn/version "6.00-beta-16-2"}
-                com.clojure-goes-fast/clj-java-decompiler {:mvn/version "0.3.4"}
-                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.2.2"}}
-   :extra-paths ["dev/src" "test"]
-   }
+                org.clojure/data.int-map {:mvn/version "1.3.0"}
+                techascent/tech.viz {:mvn/version "6.00-beta-16-4"}
+                com.clojure-goes-fast/clj-java-decompiler {:mvn/version "0.3.6"}
+                com.clojure-goes-fast/clj-memory-meter {:mvn/version "0.3.0"}}
+   :extra-paths ["dev/src" "test"]}
   :nospec {:jvm-opts ["-Dclojure.spec.skip-macros=true" "-Xverify:none"]}
   :jdk-19 {:jvm-opts ["-Djdk.attach.allowAttachSelf=true" "--illegal-access=permit"]}
   :build
-  {:deps {io.github.clojure/tools.build {:git/tag "v0.9.6" :git/sha "8e78bcc"}} 
+  {:deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
    :ns-default build}
-  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.02.12"}}
+  :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2024.08.29"}}
               :main-opts ["-m" "clj-kondo.main"]}
   :test
-  {:extra-deps {com.cognitect/test-runner
-                {:git/url "https://github.com/cognitect-labs/test-runner"
-                 :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
-                ch.qos.logback/logback-classic {:mvn/version "1.1.3"}}
+  {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
+                lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
+                lambdaisland/kaocha-cloverage {:mvn/version "1.1.89"}}
    :extra-paths ["test"]
-   :main-opts ["-m" "cognitect.test-runner"]}
+   :main-opts ["-m" "kaocha.runner"]}
   :codox
   {:extra-deps {codox-theme-rdash/codox-theme-rdash {:mvn/version "0.1.2"}
-                nrepl/nrepl {:mvn/version "0.8.3"}
-                cider/cider-nrepl {:mvn/version "0.25.5"}
+                nrepl/nrepl {:mvn/version "1.3.0"}
+                cider/cider-nrepl {:mvn/version "0.50.2"}
                 com.cnuernber/codox {:mvn/version "1.001"}}
    :exec-fn codox.main/-main
    :exec-args {:group-id "com.cnuernber"
@@ -65,13 +63,13 @@
                             ham-fisted.hlet
                             ham-fisted.primitive-invoke]}}
   :deploy
-  {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
+  {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}
    :exec-fn deps-deploy.deps-deploy/deploy
    :exec-args {:installer :remote
                :sign-releases? true
                :artifact "target/ham-fisted.jar"}}
   :install
-  {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
+  {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}
    :exec-fn deps-deploy.deps-deploy/deploy
    :exec-args {:installer :local
                :artifact "target/ham-fisted.jar"}}}}

--- a/scripts/install
+++ b/scripts/install
@@ -2,7 +2,6 @@
 
 set -e
 
-
 scripts/run-tests
 clj -T:build jar
 cp target/classes/META-INF/maven/com.cnuernber/ham-fisted/pom.xml .

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 scripts/compile
-clojure -A:dev -M:test
+clojure -M:dev:test

--- a/test/ham_fisted/hash_map_test.clj
+++ b/test/ham_fisted/hash_map_test.clj
@@ -8,7 +8,7 @@
   (:import [java.util ArrayList Collections Map Collection]
            [java.util.function BiFunction BiConsumer]
            [java.util.concurrent ForkJoinPool Future Callable]
-           [ham_fisted MutHashTable LongMutHashTable PersistentHashMap PersistentLongHashMap]))
+           [ham_fisted PersistentHashMap PersistentLongHashMap]))
 
 (defonce orig api/empty-map)
 
@@ -76,8 +76,8 @@
         (is (= n-left (count disdata)))
         (is (= n-elems (count alldata)))
         (is (= dissoc-data (set (keys disdata))))
-        (is (= data (set (keys alldata))))
-        ))))
+        (is (= data (set (keys alldata))))))))
+        
 
 
 (def map-constructors
@@ -172,8 +172,8 @@
   [[:java-hashmap java-hashmap]
    [:hamf-hashmap hamf-hashmap]
    [:clj-transient clj-transient]
-   [:hamf-transient hamf-transient]
-   ])
+   [:hamf-transient hamf-transient]])
+   
 
 
 (defn profile-datastructures
@@ -330,7 +330,7 @@
                                           (.apply ^BiFunction bifn lhs rhs)))]
                     {:construct-fn clj-transient
                      :merge-fn #(merge-with (make-merge-fn %1) %2 %3)
-                     :reduce-fn #(apply merge-with (make-merge-fn %1) %2)})
+                     :reduce-fn #(apply merge-with (make-merge-fn %1) %2)})})
    ;;jdk-8 - 1000
    ;; {:union-disj-μs 11.491328581829329,
    ;;  :union-μs 30.876507346896837,
@@ -339,7 +339,7 @@
    ;; {:union-disj-μs 2461.248479674797,
    ;;  :union-μs 5106.405916666667,
    ;;  :name :hamf-hashmap}
-   })
+   
 
 
 (defn benchmark-union
@@ -418,7 +418,7 @@
 
     (find (map-fn {}) nil) nil
     (find (map-fn {:a 1}) nil) nil
-    (find (map-fn {:a 1 :b 2}) nil) nil ))
+    (find (map-fn {:a 1 :b 2}) nil) nil))
 
 
 
@@ -464,7 +464,7 @@
     (diff (keys (map-fn {:a 1 :b 2})) '(:a :b)) nil
     (keys (api/hash-map)) nil
     (keys (api/hash-map :a 1)) '(:a)
-    (diff (keys (api/hash-map :a 1 :b 2)) '(:a :b)) nil )
+    (diff (keys (api/hash-map :a 1 :b 2)) '(:a :b)) nil)
 
   (let [m (map-fn {:a 1 :b 2})
         k (keys m)]
@@ -485,7 +485,7 @@
 
     (vals (api/hash-map)) nil
     (vals (api/hash-map :a 1)) '(1)
-    (diff (vals (api/hash-map :a 1 :b 2)) '(1 2)) nil )   ; (vals (hash-map :a 1 :b 2)) '(1 2)
+    (diff (vals (api/hash-map :a 1 :b 2)) '(1 2)) nil)   ; (vals (hash-map :a 1 :b 2)) '(1 2)
 
   (let [m (map-fn {:a 1 :b 2})
         v (vals m)]
@@ -517,8 +517,8 @@
 
   (do
     (def hm (HashMap.))
-    (def orig PersistentHashMap/EMPTY)
-    )
+    (def orig PersistentHashMap/EMPTY))
+    
 
   (dotimes [idx 100]
     (.put hm idx idx))
@@ -836,14 +836,14 @@
            :location {"bilbo" "Shire"}})
 
   (defn mutable2d [m]
-    (let [hm (api/mut-hashtable-map nil m) ]
+    (let [hm (api/mut-hashtable-map nil m)]
       (reduce-kv (fn [acc k v]
-                   (assoc! acc k (api/mut-hashtable-map))) hm hm )))
+                   (assoc! acc k (api/mut-hashtable-map))) hm hm)))
 
   (defn eq-mutable2d [m]
-    (let [hm (api/mut-hashtable-map nil m) ]
+    (let [hm (api/mut-hashtable-map nil m)]
       (reduce-kv (fn [acc k v]
-                   (assoc! acc k (api/mut-hashtable-map nil {:hash-provider api/equal-hash-provider} v))) hm hm )))
+                   (assoc! acc k (api/mut-hashtable-map nil {:hash-provider api/equal-hash-provider} v))) hm hm)))
 
   (def mdb (mutable2d db))
 
@@ -873,5 +873,5 @@
     (def ht (ham_fisted.HashTable. api/equal-hash-provider))
     (.put ht "bilbo" "baggins"))
 
-  (crit/quick-bench (.get ^ham_fisted.HashTable ht "bilbo"))
-  )
+  (crit/quick-bench (.get ^ham_fisted.HashTable ht "bilbo")))
+  

--- a/test/ham_fisted/test_setup.clj
+++ b/test/ham_fisted/test_setup.clj
@@ -1,0 +1,14 @@
+(ns ham-fisted.test-setup
+  "Things we need to do in order to run tests with a smile"
+  (:require [kaocha.hierarchy :as hierarchy]))
+
+(hierarchy/derive! ::ignore :kaocha/known-key)
+
+(defn defuse-zero-assertions
+  "Don't fail the test suite if we hide an `is` within a `doseq`.
+
+  See also https://cljdoc.org/d/lambdaisland/kaocha/1.80.1274/doc/-clojure-test-assertion-extensions#detecting-missing-assertions"
+  [event]
+  (if (= (:type event) :kaocha.type.var/zero-assertions)
+    (assoc event :type ::ignore)
+    event))

--- a/tests.edn
+++ b/tests.edn
@@ -9,8 +9,8 @@
             :kaocha.plugin.junit-xml/target-file "target/junit.xml"
             :kaocha.plugin.junit-xml/add-location-metadata? true
             :cloverage/opts {:ns-exclude-regex []
-                             :text? false
-                             :lcov? false
+                             :text? true
+                             :lcov? true
                              :high-watermark 80
                              :fail-threshold 0
                              :output "target/coverage"

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,44 @@
+#kaocha/v1 {:capture-output?                 false
+            :kaocha/fail-fast?               false
+            :plugins                         [:kaocha.plugin/profiling
+                                              :kaocha.plugin/print-invocations
+                                              :kaocha.plugin/junit-xml
+                                              :kaocha.plugin/cloverage
+                                              :kaocha.plugin/hooks
+                                              :preloads]
+            :kaocha.plugin.junit-xml/target-file "target/junit.xml"
+            :kaocha.plugin.junit-xml/add-location-metadata? true
+            :cloverage/opts {:ns-exclude-regex []
+                             :text? false
+                             :lcov? false
+                             :high-watermark 80
+                             :fail-threshold 0
+                             :output "target/coverage"
+                             :low-watermark 50
+                             :summary? true
+                             :coveralls? false
+                             :emma-xml? false
+                             :html? true
+                             :nop? false
+                             :codecov? true}
+            :kaocha.hooks/pre-report         [ham-fisted.test-setup/defuse-zero-assertions]
+            :kaocha.plugin.preloads/ns-names [ham-fisted.test-setup]
+            :tests                           [{:id                              :unit
+                                               :plugins                         [:kaocha.plugin/profiling
+                                                                                 :kaocha.plugin/print-invocations
+                                                                                 :kaocha.plugin/junit-xml
+                                                                                 :kaocha.plugin/hooks
+                                                                                 :preloads]
+                                               :kaocha/source-paths             ["src"]
+                                               :kaocha/test-paths               ["test"]
+                                               :ns-patterns                     [".*-test"]}
+                                              {:id                              :coverage
+                                               :plugins                         [:kaocha.plugin/profiling
+                                                                                 :kaocha.plugin/print-invocations
+                                                                                 :kaocha.plugin/junit-xml
+                                                                                 :kaocha.plugin/cloverage
+                                                                                 :kaocha.plugin/hooks
+                                                                                 :preloads]
+                                               :kaocha/source-paths             ["src"]
+                                               :kaocha/test-paths               ["test"]
+                                               :ns-patterns                     [".*-test"]}]}


### PR DESCRIPTION
- Swap the tests runner to kaocha.
- Add test coverage using clovegage plugin for kaocha.
- Integrate coverage reporting with PRs via LCOV action.
- Bump several dependencies, I didn't see any problems having reviewed changelogs/release notes, but if you would like take a closer look.
- Bumping deps I noticed that some newer versions of deps fail with Jdk 8 due to being compiled with newer JDK 11, so I configured GH Actions to run with JDK 8 -> 22 via mise-en-place.