### PR TITLE
move clj-kondo skip-comments linter out of exported config

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,2 @@
-{:config-paths ["../resources/clj-kondo.exports/cnuernber/ham-fisted"]}
+{:skip-comments true
+ :config-paths ["../resources/clj-kondo.exports/cnuernber/ham-fisted"]}

--- a/resources/clj-kondo.exports/cnuernber/ham-fisted/config.edn
+++ b/resources/clj-kondo.exports/cnuernber/ham-fisted/config.edn
@@ -1,5 +1,4 @@
-{:skip-comments true
- :lint-as {ham-fisted.defprotocol/defprotocol clojure.core/defprotocol
+{:lint-as {ham-fisted.defprotocol/defprotocol clojure.core/defprotocol
            ham-fisted.defprotocol/extend-protocol clojure.core/extend-protocol
            ham-fisted.defprotocol/extend-type clojure.core/extend-type}
  :hooks {:analyze-call {ham-fisted.hlet/let hooks.ham-fisted/analyze-hlet-macro


### PR DESCRIPTION
Remove skip-comments from exported linter